### PR TITLE
Add logging to API layer (closes #70)

### DIFF
--- a/ASSIGNMENT_12/api/__init__.py
+++ b/ASSIGNMENT_12/api/__init__.py
@@ -51,6 +51,17 @@ from services import (
     UniversityProgrammeService,
 )
 
+# ────────────────────────────────────────────────────────────────────────────
+# Logging configuration
+# ────────────────────────────────────────────────────────────────────────────
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger("unimatch.api")
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Pydantic schemas (module level — required for correct JSON body binding)
 # ─────────────────────────────────────────────────────────────────────────────
@@ -216,6 +227,32 @@ def create_app() -> FastAPI:
         contact={"name": "UniMatch Team"},
         license_info={"name": "MIT"},
     )
+
+    # ────────────────────────────────────────────────────────────────────
+    # Request logging middleware
+    # Logs every endpoint call (INFO), 404 responses (WARNING),
+    # and unexpected exceptions (ERROR).
+    # ────────────────────────────────────────────────────────────────────
+    @fastapi_app.middleware("http")
+    async def log_requests(request, call_next):
+        logger.info("%s %s called", request.method, request.url.path)
+        try:
+            response = await call_next(request)
+        except Exception as exc:
+            logger.error(
+                "Unexpected exception on %s %s: %s",
+                request.method,
+                request.url.path,
+                exc,
+            )
+            raise
+        if response.status_code == 404:
+            logger.warning(
+                "404 Not Found: %s %s",
+                request.method,
+                request.url.path,
+            )
+        return response
 
     learner_repo = InMemoryLearnerProfileRepository()
     programme_repo = InMemoryUniversityProgrammeRepository()


### PR DESCRIPTION
## Description
Adds Python's built-in `logging` module to the API layer as described in #70. Implemented as FastAPI HTTP middleware so every endpoint is automatically logged without modifying individual route handlers.

## Type of Change
- [x] New feature

## Related Issues
Fixes #70

## Implementation Notes
- `main.py` is a thin entry point; the actual FastAPI app and endpoints live in `api/__init__.py`, so the logging was added there.
- Added a module-level logger configured with `logging.basicConfig` at INFO level.
- Added `@fastapi_app.middleware("http")` inside `create_app()` that:
  - Logs **INFO** when each endpoint is called (`{method} {path} called`)
  - Logs **WARNING** when the response status is 404
  - Logs **ERROR** when an unhandled exception occurs, then re-raises

## Testing
- Ran `uvicorn main:app --reload` and manually verified all three log levels:
  - `GET /api/learners` → INFO log
  - `GET /api/nonexistent` → INFO + WARNING (404) logs
- All 73 existing tests pass (`python -m pytest tests/ -v`)
- No breaking changes to existing API behavior

## Checklist
- [x] Tests pass (73/73)
- [x] No breaking changes
- [x] Follows PEP 8 style
- [x] Commit message references the issue